### PR TITLE
missing NAME section in pod

### DIFF
--- a/lib/PPIx/EditorTools/FindUnmatchedBrace.pm
+++ b/lib/PPIx/EditorTools/FindUnmatchedBrace.pm
@@ -16,6 +16,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::FindUnmatchedBrace - PPI-based unmatched-brace-finder
+
 =head1 SYNOPSIS
 
   my $brace = PPIx::EditorTools::FindUnmatchedBrace->new->find(

--- a/lib/PPIx/EditorTools/FindVariableDeclaration.pm
+++ b/lib/PPIx/EditorTools/FindVariableDeclaration.pm
@@ -14,6 +14,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::FindVariableDeclaration - inds where a variable was declared using PPI
+
 =head1 SYNOPSIS
 
   # finds declaration of variable at cursor

--- a/lib/PPIx/EditorTools/IntroduceTemporaryVariable.pm
+++ b/lib/PPIx/EditorTools/IntroduceTemporaryVariable.pm
@@ -19,6 +19,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::IntroduceTemporaryVariable - Introduces a temporary variable using PPI
+
 =head1 SYNOPSIS
 
     my $munged = PPIx::EditorTools::IntroduceTemporaryVariable->new->introduce(

--- a/lib/PPIx/EditorTools/Lexer.pm
+++ b/lib/PPIx/EditorTools/Lexer.pm
@@ -16,6 +16,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::Lexer - Simple Lexer used for syntax highlighting
+
 =head1 SYNOPSIS
 
   PPIx::EditorTools::Lexer->new->lexer(

--- a/lib/PPIx/EditorTools/Outline.pm
+++ b/lib/PPIx/EditorTools/Outline.pm
@@ -204,6 +204,10 @@ __END__
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::Outline - Collect use pragmata, modules, subroutiones, methods, attributes
+
 =head1 SYNOPSIS
 
   my $outline = PPIx::EditorTools::Outline->new->find(

--- a/lib/PPIx/EditorTools/RenamePackage.pm
+++ b/lib/PPIx/EditorTools/RenamePackage.pm
@@ -18,6 +18,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::RenamePackage - Change the package name
+
 =head1 SYNOPSIS
 
     my $munged = PPIx::EditorTools::RenamePackage->new->rename(

--- a/lib/PPIx/EditorTools/RenamePackageFromPath.pm
+++ b/lib/PPIx/EditorTools/RenamePackageFromPath.pm
@@ -22,6 +22,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::RenamePackageFromPath -Change the package name based on the files path
+
 =head1 SYNOPSIS
 
     my $munged = PPIx::EditorTools::RenamePackageFromPath->new->rename(

--- a/lib/PPIx/EditorTools/RenameVariable.pm
+++ b/lib/PPIx/EditorTools/RenameVariable.pm
@@ -14,6 +14,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::RenameVariable - Lexically replace a variable name in Perl code
+
 =head1 SYNOPSIS
 
     my $munged = PPIx::EditorTools::RenameVariable->new->rename(

--- a/lib/PPIx/EditorTools/ReturnObject.pm
+++ b/lib/PPIx/EditorTools/ReturnObject.pm
@@ -11,6 +11,10 @@ our $VERSION = '0.18';
 
 =pod
 
+=head1 NAME
+
+PPIx::EditorTools::ReturnObject - Simple object to return values from PPIx::EditorTools
+
 =head1 SYNOPSIS
 
   my $brace = PPIx::EditorTools::FindUnmatchedBrace->new->find(


### PR DESCRIPTION
PPIx-EditorTools 0.15 reorganized the POD and lost the NAME section
for all modules. When converted to a manpage, this section is used
for indexing and thus should exist everywhere.

adding the NAME section back
