### PR TITLE
Fix dependency on pseudo-dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -11,22 +11,15 @@ requires "strict" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {
-  requires "Class::Accessor" => "0";
   requires "ExtUtils::MakeMaker" => "0";
   requires "File::Spec" => "0";
   requires "File::Temp" => "0";
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
-  requires "Method::Signatures" => "0";
-  requires "Moose" => "0";
-  requires "MooseX::Declare" => "0";
   requires "Test::Differences" => "0";
   requires "Test::Exception" => "0";
   requires "Test::More" => "0";
   requires "Test::Most" => "0";
-  requires "autodie" => "0";
-  requires "lib" => "0";
-  requires "version" => "0";
 };
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -10,8 +10,13 @@ license = Perl_5
 copyright_holder = The Padre development team as listed in Padre.pm.
 copyright_year   = 2011
 
+[FileFinder::Filter / NoExecTests]
+finder = :TestFiles
+skip  = outline
+
 [@Filter]
 -bundle=@YANICK
 -remove=Covenant
 NextVersion::Semantic.format=%d.%2d
 AutoPrereqs.skip=Abc
+AutoPrereqs.test_finder = NoExecTests


### PR DESCRIPTION
These aren't really needed at test time, as the code they're in is
never executed by Perl, and is only parsed with PPI.

Closes: https://github.com/yanick/PPIx-EditorTools/issues/8