### PR TITLE
remove unhandled import arguments

### DIFF
--- a/t/00-ppix-editortools.t
+++ b/t/00-ppix-editortools.t
@@ -32,7 +32,7 @@ foreach my $class (@classes) {
 	my $test_object = new_ok($class);
 }
 
-use_ok( 'PPIx::EditorTools', @subs );
+use_ok( 'PPIx::EditorTools' );
 
 foreach my $subs (@subs) {
 	can_ok( 'PPIx::EditorTools', $subs );


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use_ok when the import method does not exist.